### PR TITLE
Updated package.json to use latest d3

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "gitHead": "d419b8d1619e5920925d6e23e96f3b86406a4b9b",
   "dependencies": {
-    "d3": "~3.2.0",
+    "d3": "~3.5.16",
     "tape": "~1.0.4"
   }
 }


### PR DESCRIPTION
Previous version of d3 was extremely old and depended on jsdom, which has ES6-specific syntax.
